### PR TITLE
feat(downloader): add tags support for torrent injection

### DIFF
--- a/src/nemorosa/clients/qbittorrent.py
+++ b/src/nemorosa/clients/qbittorrent.py
@@ -210,6 +210,7 @@ class QBittorrentClient(TorrentClient):
             save_path=download_dir,
             is_paused=True,
             category=config.cfg.downloader.label,
+            tags=config.cfg.downloader.tags,
             use_auto_torrent_management=False,
             is_skip_checking=hash_match,  # Skip hash checking if hash match
         )

--- a/src/nemorosa/clients/transmission.py
+++ b/src/nemorosa/clients/transmission.py
@@ -202,8 +202,13 @@ class TransmissionClient(TorrentClient):
             "download-dir": download_dir,
             "paused": True,
             "metainfo": torrent_data_b64,
-            "labels": [config.cfg.downloader.label],
         }
+
+        # Prepare labels: use tags if provided, otherwise use [label] if label is not None
+        if config.cfg.downloader.tags:
+            kwargs["labels"] = config.cfg.downloader.tags
+        elif config.cfg.downloader.label:
+            kwargs["labels"] = [config.cfg.downloader.label]
 
         # Make direct RPC call to get raw response
         query = {"method": RpcMethod.TorrentAdd, "arguments": kwargs}


### PR DESCRIPTION
https://github.com/KyokoMiki/nemorosa/issues/19

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-18 14:59:45 UTC

### Greptile Summary

This PR adds tags support for torrent injection across qBittorrent and Transmission clients, implementing the feature requested in issue #19. The changes introduce a new optional `tags` field in the downloader configuration alongside the existing `label` field, allowing users to organize torrents with more granular metadata.

The implementation is client-aware: in qBittorrent, tags work alongside the existing category system, while in Transmission, tags take precedence over labels when configured. The configuration schema has been updated with comprehensive validation to ensure tags cannot be empty lists or contain empty strings, maintaining data integrity. The existing label functionality remains fully backward compatible.

This change integrates seamlessly with the existing configuration system and torrent client abstraction layer, following the established pattern of client-specific feature support through the unified configuration interface.

### Important Files Changed

<details>
<summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|--------|----------|
| src/nemorosa/config.py |4/5 | Added optional tags field with validation and updated configuration template |
| src/nemorosa/clients/qbittorrent.py | 4/5 | Added tags parameter to torrent injection using configuration value |
| src/nemorosa/clients/transmission.py | 5/5 | Implemented tags support with fallback to label for backward compatibility |

</details>

### Confidence score: 4/5

- This PR is safe to merge with minimal risk as it maintains backward compatibility while adding new optional functionality
- Score reflects well-implemented feature with proper validation, but deducted one point due to lack of explicit error handling for invalid tags in qBittorrent client and potential runtime issues if configuration validation is bypassed
- Pay close attention to src/nemorosa/config.py for the validation logic and src/nemorosa/clients/qbittorrent.py for the direct parameter passing without additional validation

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CLI as "CLI/API"
    participant Config as "Configuration"
    participant Core as "NemorosaCore"
    participant Client as "TorrentClient"
    participant QB as "qBittorrent"
    participant Trans as "Transmission"

    User->>CLI: "Inject torrent with tags"
    CLI->>Config: "Load downloader config"
    Config-->>CLI: "Return config with tags/label"
    CLI->>Core: "Process torrent injection"
    Core->>Client: "_add_torrent(torrent_data, download_dir, hash_match)"
    
    alt qBittorrent Client
        Client->>Config: "Get cfg.downloader.tags"
        Config-->>Client: "Return tags list"
        Client->>QB: "torrents_add() with tags and category"
        Note over QB: "Uses both tags and category(label)"
        QB-->>Client: "Return 'Ok.' or 'Fails.'"
        Client-->>Core: "Return torrent hash"
    else Transmission Client
        Client->>Config: "Get cfg.downloader.tags"
        Config-->>Client: "Return tags list"
        alt Tags are configured
            Client->>Trans: "torrent-add with labels=tags"
        else No tags, but label exists
            Client->>Trans: "torrent-add with labels=[label]"
        end
        Trans-->>Client: "Return torrent-added or torrent-duplicate"
        Client-->>Core: "Return torrent hash or raise TorrentConflictError"
    end
    
    Core-->>CLI: "Return injection result"
    CLI-->>User: "Display injection status"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->