### PR TITLE
feat: add Docker Hub CI/CD pipeline and update README with rTorrent support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Run Ruff
-        uses: astral-sh/ruff-action@v3.2.2
+        uses: astral-sh/ruff-action@v3
 
   pyright:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   VERSION: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
   UPDATE_VERSION: ${{ github.event_name == 'release' && 'true' || 'false' }}
 
@@ -26,7 +24,7 @@ jobs:
           token: ${{ secrets.BUMP_VERSION_TOKEN_ACTION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -76,49 +74,44 @@ jobs:
           fetch-depth: 0 # Ensures we get all history for tag retrieval and pushing
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Get lowercase repo name
-        id: get_lowercase_repo_name
-        run: |
-          REPO_NAME=${{ env.IMAGE_NAME }} 
-          echo "LOWER_CASE_REPO_NAME=${REPO_NAME,,}" >> $GITHUB_ENV
-
-      - name: Debug VERSION and UPDATE_VERSION
-        run: |
-          echo "VERSION=${{ env.VERSION }}"
-          echo "UPDATE_VERSION=${{ env.UPDATE_VERSION }}"
+          images: |
+            docker.io/${{ github.repository }}
+            ghcr.io/${{ github.repository }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.LOWER_CASE_REPO_NAME }}:${{ env.VERSION }}
-            ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -135,7 +128,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Unlike traditional music torrent cross-seeding tools that can only match torrent
   - **Deluge**
   - **rTorrent**
 
-  **Note**: If using Transmission, Deluge, rTorrent, or qBittorrent versions prior to 4.5.0, `nemorosa` needs access to the client's torrents directory. When running in Docker, ensure you map the torrents directory to the `nemorosa` container.
+  **Note**: If using qBittorrent < 4.5.0, Transmission, Deluge, or rTorrent, `nemorosa` needs access to the client's torrents directory. When running in Docker, ensure you map the torrents directory to the `nemorosa` container.
 - Access to Gazelle-based target trackers for cross-seeding (**source sites can be ANY type**):
   - **GazelleJSONAPI**: RED, OPS, DIC
   - **Gazelle (Legacy)**: LZTR, Libble


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-18 19:29:08 UTC

### Greptile Summary

This PR modernizes the CI/CD infrastructure and updates documentation for rTorrent support. The changes include: (1) adding Docker Hub as an additional registry for publishing images alongside GitHub Container Registry, (2) upgrading GitHub Actions dependencies to use major version tags (ruff-action v3, setup-uv v7, docker actions v3/v5/v6) for automatic minor/patch updates, (3) documenting rTorrent as a newly supported torrent client in the README with improved formatting, and (4) simplifying the release workflow by replacing manual tag/label construction with `docker/metadata-action`. The rTorrent support integrates into the existing multi-client architecture (`/src/nemorosa/clients/`), joining Transmission, qBittorrent, and Deluge. The workflow changes eliminate hardcoded environment variables in favor of action-based metadata generation, making the pipeline more maintainable and less error-prone.

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `.github/workflows/lint.yml` | 5/5 | Updates ruff-action to v3 and setup-uv to v7 using major version tags for automatic minor/patch updates |
| `README.md` | 5/5 | Documents rTorrent support, improves formatting with backticks for `nemorosa`, and updates license badge to static format |
| `.github/workflows/release.yml` | 3/5 | Adds Docker Hub publishing, upgrades actions, and simplifies metadata extraction; requires new secrets configuration |

</details>

### Confidence score: 4/5

- This PR is safe to merge with only minor deployment considerations
- Score reflects the need to configure two new Docker Hub secrets (`DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`) before the release workflow can execute successfully; without these, the Docker Hub login will fail but the workflow will still publish to GHCR
- `.github/workflows/release.yml` requires secret configuration: ensure `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are added to repository secrets before merging to enable dual-registry publishing

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as "Developer"
    participant GitHub as "GitHub"
    participant UpdateJob as "update-version Job"
    participant DockerJob as "build-and-push-image Job"
    participant PyPIJob as "publish-pypi Job"
    participant DH as "Docker Hub"
    participant GHCR as "GitHub Container Registry"
    participant PyPI as "PyPI"

    User->>GitHub: "Create Release / Trigger Workflow"
    GitHub->>UpdateJob: "Start (if release event)"
    UpdateJob->>UpdateJob: "Checkout code"
    UpdateJob->>UpdateJob: "Install uv"
    UpdateJob->>UpdateJob: "Update pyproject.toml version"
    UpdateJob->>UpdateJob: "Update __init__.py version"
    UpdateJob->>UpdateJob: "Regenerate uv.lock"
    UpdateJob->>UpdateJob: "Update CHANGELOG.md"
    UpdateJob->>GitHub: "Commit and push to main"
    
    UpdateJob->>DockerJob: "Trigger (needs: update-version)"
    DockerJob->>DockerJob: "Checkout main branch"
    DockerJob->>DockerJob: "Set up QEMU & Docker Buildx"
    DockerJob->>DockerJob: "Install uv"
    DockerJob->>DH: "Login to Docker Hub"
    DockerJob->>GHCR: "Login to GHCR"
    DockerJob->>DockerJob: "Extract metadata (tags, labels)"
    DockerJob->>DockerJob: "Build multi-platform image"
    DockerJob->>DH: "Push Docker image"
    DockerJob->>GHCR: "Push Docker image"
    
    UpdateJob->>PyPIJob: "Trigger (needs: update-version)"
    PyPIJob->>PyPIJob: "Checkout main branch"
    PyPIJob->>PyPIJob: "Install uv"
    PyPIJob->>PyPIJob: "Set up Python"
    PyPIJob->>PyPIJob: "Install dependencies"
    PyPIJob->>PyPIJob: "Build package"
    PyPIJob->>PyPI: "Publish package"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->