### PR TITLE
feat(docker): support timezone configuration via TZ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ FROM python:3.13-slim-bookworm
 # Set working directory
 WORKDIR /app
 
+# Accept optional timezone argument
+ARG TZ
+
 # Copy the virtual environment from builder stage
 COPY --from=builder /app/.venv /app/.venv
 
@@ -53,5 +56,5 @@ ENV XDG_DATA_HOME=/app/data
 # Expose port for web interface
 EXPOSE 8256
 
-# Use the installed application directly via Python module
-ENTRYPOINT ["nemorosa"]
+# Configure timezone at runtime: set TZ env var and system timezone files
+ENTRYPOINT ["sh", "-c", "[ -n \"$TZ\" ] && [ -f \"/usr/share/zoneinfo/$TZ\" ] && ln -sf \"/usr/share/zoneinfo/$TZ\" /etc/localtime && echo \"$TZ\" > /etc/timezone || true; exec nemorosa \"$@\""]


### PR DESCRIPTION
https://github.com/KyokoMiki/nemorosa/issues/34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Container timezone is now configurable at runtime via the TZ environment variable; the selected timezone is applied when the container starts (previously fixed to UTC).
  * If TZ is unset or invalid, startup falls back to the prior behavior, preserving compatibility with existing deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->