### PR TITLE
feat(filelinking): add directory creation mode configuration option

### DIFF
--- a/src/nemorosa/filelinking.py
+++ b/src/nemorosa/filelinking.py
@@ -124,7 +124,7 @@ def create_file_link(source_path: str, dest_path: str, link_type: LinkType | Non
     try:
         # Ensure destination directory exists
         dest_dir = os.path.dirname(dest_path)
-        os.makedirs(dest_dir, exist_ok=True)
+        os.makedirs(dest_dir, mode=config.cfg.linking.dir_mode, exist_ok=True)
 
         # Check if destination already exists
         if os.path.exists(dest_path):


### PR DESCRIPTION
https://github.com/KyokoMiki/nemorosa/issues/33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable directory permissions for file-linking. Destination directories now use a user-set octal-style permission (default 775); invalid or out-of-range values are rejected.

* **Documentation**
  * Updated default and example configuration to include the new directory-permission setting with explanatory notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->