### PR TITLE
Add timestamps to log output with custom format

### DIFF
--- a/src/nemorosa/logger.py
+++ b/src/nemorosa/logger.py
@@ -97,7 +97,7 @@ def init_logger(loglevel: LogLevel = LogLevel.INFO) -> None:
 
     # Create console handler with colored formatter
     handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(DefaultFormatter(fmt="%(levelprefix)s %(message)s"))
+    handler.setFormatter(DefaultFormatter(fmt="%(asctime)s | %(levelprefix)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S"))
     logger.addHandler(handler)
 
     # Prevent propagation to avoid duplicate logs


### PR DESCRIPTION
## Description
Adds timestamps to log output with a clean, readable format.

## Changes
- Modified `logger.py` to include timestamps in format: `YYYY-MM-DD HH:MM:SS | LEVEL | message`
- Uses custom `datefmt` to avoid microseconds clutter
- Improves upon the suggested format in issue #34 

## Example Output
Before:
```
INFO:     Starting Nemorosa web server on 0.0.0.0:8256
```

After:
```
2025-11-07 21:59:48 | INFO:     Starting Nemorosa web server on 0.0.0.0:8256
```

## Testing
Tested in production - logs are clear and timestamps aid in debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Log messages now include timestamps in YYYY-MM-DD HH:MM:SS format, providing better visibility into when events occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->