### PR TITLE
Handle qBittorrent auth bypass correctly

### DIFF
--- a/src/nemorosa/clients/qbittorrent.py
+++ b/src/nemorosa/clients/qbittorrent.py
@@ -88,7 +88,8 @@ class QBittorrentClient(TorrentClient):
             password=client_config.password,
         )
         # Authenticate with qBittorrent
-        self.client.auth_log_in()
+        if client_config.username and client_config.password:
+            self.client.auth_log_in()
 
         # Initialize sync state for incremental updates
         self._last_rid = 0


### PR DESCRIPTION
This change fixes qBittorrent Web API initialization when authentication bypass
is enabled for whitelisted subnets.

The client no longer supplies credentials or attempts to call auth_log_in()
when username/password are not configured, preventing unnecessary login
failures while preserving compatibility with authenticated setups.

No functional changes to torrent, sync, or monitoring logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved qBittorrent authentication handling: The application now only attempts authentication when credentials are provided in the configuration, preventing unnecessary login attempts when credentials are missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->