### PR TITLE
fix(logging): unify uvicorn log format with nemorosa

### DIFF
--- a/src/nemorosa/webserver.py
+++ b/src/nemorosa/webserver.py
@@ -395,6 +395,21 @@ def run_webserver():
 
     # Import uvicorn here to avoid import issues
     import uvicorn
+    from uvicorn.config import LOGGING_CONFIG
+
+    # Override uvicorn log format to match nemorosa log format
+    LOGGING_CONFIG["formatters"]["default"]["fmt"] = "%(asctime)s | %(levelprefix)s %(message)s"
+    LOGGING_CONFIG["formatters"]["default"]["datefmt"] = "%Y-%m-%d %H:%M:%S"
+    LOGGING_CONFIG["formatters"]["access"]["fmt"] = (
+        '%(asctime)s | %(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
+    )
+    LOGGING_CONFIG["formatters"]["access"]["datefmt"] = "%Y-%m-%d %H:%M:%S"
 
     # Run server
-    uvicorn.run("nemorosa.webserver:app", host=host, port=port, log_level=log_level, reload=False)  # type: ignore[arg-type]
+    uvicorn.run(
+        app="nemorosa.webserver:app",
+        host=host,  # type: ignore[arg-type]
+        port=port,
+        log_level=log_level,
+        reload=False,
+    )


### PR DESCRIPTION
- Configure uvicorn with custom log_config to match nemorosa log format
- Use consistent timestamp format (YYYY-MM-DD HH:MM:SS) across all logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and improved server logging so startup and runtime logs are more consistent and easier to read.
  * Adjusted server startup invocation to ensure the application launches reliably with the updated logging behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->