### PR TITLE
feat: add support for duplicate_categories in qBittorrent and Deluge

### DIFF
--- a/src/nemorosa/clients/client_common.py
+++ b/src/nemorosa/clients/client_common.py
@@ -232,7 +232,11 @@ class TorrentClient(ABC):
 
     @abstractmethod
     async def _add_torrent(
-        self, torrent_data: bytes, download_dir: str, hash_match: bool
+        self,
+        torrent_data: bytes,
+        download_dir: str,
+        hash_match: bool,
+        local_torrent_hash: str = "",
     ) -> str:
         """Add torrent to client, return torrent hash.
 
@@ -240,6 +244,8 @@ class TorrentClient(ABC):
             torrent_data (bytes): Torrent file data.
             download_dir (str): Download directory.
             hash_match (bool): Whether this is a hash match, if True, skip verification.
+            local_torrent_hash (str): Hash of the original local torrent.
+                Used for duplicate_categories feature to fetch category on demand.
 
         Returns:
             str: Torrent hash.
@@ -870,6 +876,7 @@ class TorrentClient(ABC):
         local_torrent_name: str,
         rename_map: dict,
         hash_match: bool,
+        local_torrent_hash: str = "",
     ) -> tuple[bool, bool]:
         """Inject torrent into client (includes complete logic).
 
@@ -881,6 +888,8 @@ class TorrentClient(ABC):
             local_torrent_name (str): Local torrent name.
             rename_map (dict): File rename mapping.
             hash_match (bool): Whether this is a hash match, if True, skip verification.
+            local_torrent_hash (str): Hash of the original local torrent.
+                Used for duplicate_categories feature.
 
         Returns:
             tuple[bool, bool]: (success, verified) where:
@@ -919,7 +928,10 @@ class TorrentClient(ABC):
         # Add torrent to client
         try:
             torrent_hash = await self._add_torrent(
-                torrent_object.dump(), download_dir, hash_match
+                torrent_object.dump(),
+                download_dir,
+                hash_match,
+                local_torrent_hash=local_torrent_hash,
             )
         except TorrentConflictError as e:
             logger.error("Torrent injection failed due to conflict: %s", e)

--- a/src/nemorosa/clients/rtorrent.py
+++ b/src/nemorosa/clients/rtorrent.py
@@ -497,14 +497,22 @@ class RTorrentClient(TorrentClient):
         return modified_torrent.dump()
 
     async def _add_torrent(
-        self, torrent_data: bytes, download_dir: str, hash_match: bool
+        self,
+        torrent_data: bytes,
+        download_dir: str,
+        hash_match: bool,
+        local_torrent_hash: str = "",
     ) -> str:
         """Add torrent to rTorrent with optional fast resume support.
+
+        Note: rTorrent does not support duplicate_categories feature.
+        The local_torrent_hash parameter is ignored.
 
         Args:
             torrent_data (bytes): Torrent file data.
             download_dir (str): Download directory.
             hash_match (bool): Whether this is a hash match, if True, skip verification.
+            local_torrent_hash (str): Hash of the original local torrent (ignored).
 
         Returns:
             str: Torrent hash.

--- a/src/nemorosa/clients/transmission.py
+++ b/src/nemorosa/clients/transmission.py
@@ -221,14 +221,22 @@ class TransmissionClient(TorrentClient):
     # region Abstract Methods - Internal Operations
 
     async def _add_torrent(
-        self, torrent_data: bytes, download_dir: str, hash_match: bool
+        self,
+        torrent_data: bytes,
+        download_dir: str,
+        hash_match: bool,
+        local_torrent_hash: str = "",
     ) -> str:
         """Add torrent to Transmission.
+
+        Note: Transmission does not support duplicate_categories feature.
+        The local_torrent_hash parameter is ignored.
 
         Args:
             torrent_data (bytes): Torrent file data.
             download_dir (str): Download directory.
             hash_match (bool): Not used for Transmission (has fast verification).
+            local_torrent_hash (str): Hash of original local torrent (ignored).
 
         Returns:
             str: Torrent hash string.

--- a/src/nemorosa/config.py
+++ b/src/nemorosa/config.py
@@ -119,6 +119,8 @@ class DownloaderConfig(msgspec.Struct):
     client: str = ""
     label: str | None = "nemorosa"
     tags: list[str] | None = None
+    use_unified_labels: bool = True
+    duplicate_categories: bool = False
 
     def __post_init__(self):
         if not self.client or not self.client.strip():
@@ -339,7 +341,8 @@ global:
     - "home.opsfet.ch"
     - "52dic.vip"
   check_music_only: true # Whether to check music files only
-  auto_start_torrents: true # Whether to automatically start torrents after successful injection
+  # Whether to automatically start torrents after successful injection
+  auto_start_torrents: true
   # Apprise notification URLs
   # See: https://github.com/caronc/apprise/wiki
   notification_urls: []
@@ -358,7 +361,8 @@ server:
   port: 8256 # Server port
   api_key: "{token_urlsafe(32)}" # API key for accessing web interface
   # Scheduled job settings (optional, set to null to disable)
-  search_cadence: "1 day" # How often to run search job (e.g., "1 day", "6 hours", "30 minutes")
+  # e.g., "1 day", "6 hours", "30 minutes"
+  search_cadence: "1 day" # How often to run search job
   cleanup_cadence: "1 day" # How often to run cleanup job
 
 downloader:
@@ -368,7 +372,8 @@ downloader:
   # transmission+http://user:pass@host:port/transmission/rpc?torrents_dir=/path/to/session/
   # deluge://username:password@host:port/?torrents_dir=/path/to/session/
   # qbittorrent+http://username:password@host:port/?torrents_dir=/path/to/session/
-  # qbittorrent+http://username:password@host:port  # For qBittorrent 4.5.0+, torrents_dir is not needed
+  # qbittorrent+http://username:password@host:port
+  # For qBittorrent 4.5.0+, torrents_dir is not needed
 
   # For Windows: Use forward slashes (/) in torrents_dir path
   # Example: ?torrents_dir=C:/Users/username/AppData/Local/qBittorrent/BT_backup
@@ -379,6 +384,19 @@ downloader:
   # For qBittorrent, tags work with label
   # For Transmission, default to use tags, if tags is null, use [label] as fallback
   tags: null
+  # Use unified label and tags from config file. Default to true.
+  # When enabled, injected torrents will always use the label/tags specified above.
+  # When disabled, falls back to duplicate_categories behavior.
+  # Note: This setting only affects qBittorrent and Deluge.
+  # Transmission and rTorrent always use unified labels regardless of this setting.
+  use_unified_labels: true
+  # qBittorrent/Deluge specific (only takes effect when use_unified_labels is false).
+  # Whether to inject using the same labels/categories as the original torrent.
+  # - Without linking: category will be set to "{{original_category}}.nemorosa"
+  # - With linking enabled: category stays as label,
+  #   but "{{original_category}}.nemorosa" is added as tag
+  # Example: original category "Music" -> injected to "Music.nemorosa"
+  duplicate_categories: false
 
 target_site:
   # Target site settings
@@ -388,7 +406,7 @@ target_site:
     api_key: "your_api_key_here"
   - server: "https://dicmusic.com"
     cookie: "your_cookie_here" # For sites that don't support API, use cookie instead
-"""  # noqa: E501
+"""
 
     target_path.write_text(default_config, encoding="utf-8")
 

--- a/src/nemorosa/core.py
+++ b/src/nemorosa/core.py
@@ -509,12 +509,14 @@ class NemorosaCore:
         logger.debug("Rename map: %s", rename_map)
 
         # Inject torrent and handle renaming
+        # Pass local_torrent_info.hash for duplicate_categories feature
         success, _ = await self.torrent_client.inject_torrent(
             matched_torrent,
             final_download_dir,
             local_torrent_info.name,
             rename_map,
             hash_match,
+            local_torrent_info.hash,
         )
         return success
 
@@ -1230,6 +1232,7 @@ class NemorosaCore:
                 matched_torrent.name,
                 rename_map,
                 False,
+                matched_torrent.hash,
             )
             if success:
                 logger.success("Torrent injected successfully")

--- a/src/nemorosa/db.py
+++ b/src/nemorosa/db.py
@@ -99,7 +99,7 @@ class ClientTorrent(Base):
     def from_client_info(cls, info: "ClientTorrentInfo") -> "ClientTorrent":
         """Alternative constructor: Create ClientTorrent from ClientTorrentInfo.
 
-        This is a factory method that provides a convenient way to create a 
+        This is a factory method that provides a convenient way to create a
         ClientTorrent ORM object from a ClientTorrentInfo business object.
 
         Args:


### PR DESCRIPTION
https://github.com/KyokoMiki/nemorosa/issues/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new configuration options: `use_unified_labels` (enable unified label mode) and `duplicate_categories` (handle duplicate category assignment).
  * Enhanced torrent injection with intelligent label and category assignment based on existing torrent metadata and user settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->