### PR TITLE
Bugfixes: allow setting torrents_dir and non-default transmission URL paths

### DIFF
--- a/src/nemorosa/clients/client_common.py
+++ b/src/nemorosa/clients/client_common.py
@@ -1480,13 +1480,6 @@ def parse_libtc_url(url: str) -> TorrentClientConfig:
             f"Unsupported client type: {client}. "
             f"Supported clients: {', '.join(supported_clients)}"
         )
-    if (
-        client in ("transmission", "qbittorrent", "deluge") and
-        not (torrents_dir or config.cfg.downloader.torrents_dir)
-    ):
-        raise ValueError(
-            f"torrents_dir required for client: {client}."
-        )
 
     if client == "qbittorrent":
         # qBittorrent: separate auth from URL (uses hostname:port only)

--- a/src/nemorosa/clients/deluge.py
+++ b/src/nemorosa/clients/deluge.py
@@ -89,7 +89,7 @@ class DelugeClient(TorrentClient):
         super().__init__()
         client_config = parse_libtc_url(url)
         self.torrents_dir = (
-            client_config.torrents_dir or config.cfg.downloader.torrents_dir
+            config.cfg.downloader.torrents_dir or client_config.torrents_dir or ""
         )
         self.client = deluge_client.DelugeRPCClient(
             host=client_config.host or "localhost",

--- a/src/nemorosa/clients/qbittorrent.py
+++ b/src/nemorosa/clients/qbittorrent.py
@@ -100,7 +100,7 @@ class QBittorrentClient(TorrentClient):
         super().__init__()
         client_config = parse_libtc_url(url)
         self.torrents_dir = (
-            client_config.torrents_dir or config.cfg.downloader.torrents_dir
+            config.cfg.downloader.torrents_dir or client_config.torrents_dir or ""
         )
         self.client = qbittorrentapi.Client(
             host=client_config.url or "http://localhost:8080",

--- a/src/nemorosa/clients/rtorrent.py
+++ b/src/nemorosa/clients/rtorrent.py
@@ -157,9 +157,8 @@ class RTorrentClient(TorrentClient):
         super().__init__()
         client_config = parse_libtc_url(url)
         self.torrents_dir = (
-            client_config.torrents_dir or config.cfg.downloader.torrents_dir
+            config.cfg.downloader.torrents_dir or client_config.torrents_dir or ""
         )
-
 
         # Monkey-patch xmlrpc.client to mitigate XML vulnerabilities
         defusedxml.xmlrpc.monkey_patch()

--- a/src/nemorosa/clients/transmission.py
+++ b/src/nemorosa/clients/transmission.py
@@ -90,7 +90,7 @@ class TransmissionClient(TorrentClient):
         super().__init__()
         client_config = parse_libtc_url(url)
         self.torrents_dir = (
-            client_config.torrents_dir or config.cfg.downloader.torrents_dir
+            config.cfg.downloader.torrents_dir or client_config.torrents_dir or ""
         )
 
         # Ensure protocol is either 'http' or 'https'
@@ -104,7 +104,7 @@ class TransmissionClient(TorrentClient):
             password=client_config.password,
             host=client_config.host or "localhost",
             port=client_config.port or 9091,
-            path=client_config.path or "/transmission/rpc"
+            path=client_config.path or "/transmission/rpc",
         )
 
         # Use the field specifications constant

--- a/src/nemorosa/config.py
+++ b/src/nemorosa/config.py
@@ -380,6 +380,9 @@ downloader:
   # Example: ?torrents_dir=C:/Users/username/AppData/Local/qBittorrent/BT_backup
 
   client: ""
+  # The directory where your torrent client stores its .torrent files.
+  # If set, this path overrides the torrents_dir parameter in the client URL above.
+  torrents_dir: ""
   label: "nemorosa" # Download label
   # Optional tags list, only for qBittorrent and Transmission.
   # For qBittorrent, tags work with label


### PR DESCRIPTION
* Allow setting downloader.torrents_dir in config.yml
* Allow non-standard transmission URL paths

Allowing torrents_dir to be set via config.yml simplified creating a helm chart for deployment to kubernetes. The non-standard transmission URL path support is useful for users who have multiple transmission clients running behind a common reverse proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable torrent download directory.
  * Clients may now accept an optional path value from their connection URLs.

* **Improvements**
  * Smarter default resolution and fallback for client torrent directories (global → per-client → empty).
  * Connection setup now defaults to HTTP for unsupported schemes.
  * Transmission client uses a sensible default RPC path when not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->