### PR TITLE
ci(workflows): improve GitHub Actions permissions and configuration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   ruff:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -19,7 +20,8 @@ jobs:
 
   pyright:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,15 @@ jobs:
   update-version:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    permissions:
+      contents: read
     outputs:
       version: ${{ env.VERSION }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
           token: ${{ secrets.BUMP_VERSION_TOKEN_ACTION }}
 
@@ -63,9 +66,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [update-version]
     permissions:
-      contents: write
+      contents: read
       packages: write
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -120,6 +122,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [update-version]
     if: github.event_name == 'release'
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions to enforce principle of least privilege, granting explicit read-only access to repository contents for lint and release jobs.
  * Added reference to main branch in checkout steps to ensure consistent workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->