### PR TITLE
refactor(config)!: extract credentials from URL into separate config fields

### DIFF
--- a/src/nemorosa/cli.py
+++ b/src/nemorosa/cli.py
@@ -172,7 +172,7 @@ async def async_init():
     for dl_config in config.cfg.downloaders:
         logger.debug(
             "Connecting to torrent client at %s...",
-            logger.redact_url_password(dl_config.url),
+            dl_config.url,
         )
     await init_torrent_clients(
         config.cfg.downloaders,
@@ -261,7 +261,7 @@ def main():
     logger.debug("Log level: %s", config.cfg.global_config.loglevel)
     logger.debug("Torrent clients configured: %d", len(config.cfg.downloaders))
     for i, dl in enumerate(config.cfg.downloaders, 1):
-        logger.debug("  Client %d: %s", i, logger.redact_url_password(dl.url))
+        logger.debug("  Client %d: %s", i, dl.url)
     check_trackers = config.cfg.global_config.check_trackers
     logger.debug(
         "CHECK_TRACKERS: %s",

--- a/src/nemorosa/clients/deluge.py
+++ b/src/nemorosa/clients/deluge.py
@@ -7,7 +7,7 @@ import base64
 import posixpath
 import re
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 
 import deluge_client
 from anyio import Path
@@ -112,8 +112,8 @@ class DelugeClient(TorrentClient):
         self.client = deluge_client.DelugeRPCClient(
             host=parsed.hostname or "localhost",
             port=parsed.port or 58846,
-            username=unquote(parsed.username) if parsed.username else "",
-            password=unquote(parsed.password) if parsed.password else "",
+            username=downloader_config.username,
+            password=downloader_config.password,
             decode_utf8=True,
             timeout=TORRENT_CLIENT_TIMEOUT,
         )

--- a/src/nemorosa/clients/qbittorrent.py
+++ b/src/nemorosa/clients/qbittorrent.py
@@ -7,7 +7,6 @@ import os
 import posixpath
 import time
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urlparse
 
 import qbittorrentapi
 from anyio import Path
@@ -118,23 +117,15 @@ class QBittorrentClient(TorrentClient):
             scheduler=scheduler,
             notifier=notifier,
         )
-        parsed = urlparse(downloader_config.url)
         self.torrents_dir = downloader_config.torrents_dir
-        # Build URL without credentials for qBittorrent API
-        netloc = (
-            f"{parsed.hostname}:{parsed.port}"
-            if parsed.port
-            else (parsed.hostname or "")
-        )
-        clean_url = f"{parsed.scheme}://{netloc}{parsed.path}"
         self.client = qbittorrentapi.Client(
-            host=clean_url or "http://localhost:8080",
-            username=(unquote(parsed.username) if parsed.username else None),
-            password=(unquote(parsed.password) if parsed.password else None),
+            host=downloader_config.url or "http://localhost:8080",
+            username=downloader_config.username or None,
+            password=downloader_config.password or None,
             REQUESTS_ARGS={"timeout": TORRENT_CLIENT_TIMEOUT},
         )
         # Authenticate with qBittorrent
-        if parsed.username and parsed.password:
+        if downloader_config.username and downloader_config.password:
             self.client.auth_log_in()
 
         # Initialize sync state for incremental updates

--- a/src/nemorosa/clients/rtorrent.py
+++ b/src/nemorosa/clients/rtorrent.py
@@ -6,7 +6,7 @@ Provides integration with rTorrent via XML-RPC interface using SCGI transport.
 import posixpath
 import xmlrpc.client  # nosec B411
 from typing import TYPE_CHECKING
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 import anyio
 import defusedxml.xmlrpc
@@ -133,6 +133,25 @@ def _decode_bitfield(
     return decode_bitfield_bytes(bitfield_data, piece_count)
 
 
+def _build_authenticated_url(url: str, username: str, password: str | None) -> str:
+    """Build URL with embedded credentials for HTTP Basic Auth.
+
+    Args:
+        url: Original URL without credentials.
+        username: Username for authentication.
+        password: Password for authentication, or None.
+
+    Returns:
+        URL with credentials embedded in the netloc.
+    """
+    parsed = urlsplit(url)
+    quoted_user = quote(username, safe="")
+    quoted_pass = f":{quote(password, safe='')}" if password else ""
+    # Extract host:port from netloc, preserving IPv6 brackets
+    host_port = parsed.netloc.rsplit("@", 1)[-1]
+    return parsed._replace(netloc=f"{quoted_user}{quoted_pass}@{host_port}").geturl()
+
+
 def create_proxy(url: str) -> xmlrpc.client.ServerProxy:
     """Create XML-RPC proxy with SCGI support.
 
@@ -180,8 +199,17 @@ class RTorrentClient(TorrentClient):
         # Monkey-patch xmlrpc.client to mitigate XML vulnerabilities
         defusedxml.xmlrpc.monkey_patch()
 
-        # rTorrent uses XML-RPC — URL passed directly (includes auth)
-        self.client = create_proxy(downloader_config.url)
+        # rTorrent uses XML-RPC — rebuild URL with credentials for HTTP Basic Auth
+        url = (
+            _build_authenticated_url(
+                downloader_config.url,
+                downloader_config.username,
+                downloader_config.password,
+            )
+            if downloader_config.username
+            else downloader_config.url
+        )
+        self.client = create_proxy(url)
 
         # Use the field specifications constant
         self.field_config = _RTORRENT_FIELD_SPECS

--- a/src/nemorosa/clients/transmission.py
+++ b/src/nemorosa/clients/transmission.py
@@ -6,7 +6,7 @@ Provides integration with Transmission via its RPC interface.
 import base64
 import posixpath
 from typing import TYPE_CHECKING
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 
 import msgspec
 import transmission_rpc
@@ -118,8 +118,8 @@ class TransmissionClient(TorrentClient):
 
         self.client = transmission_rpc.Client(
             protocol=protocol,
-            username=(unquote(parsed.username) if parsed.username else None),
-            password=(unquote(parsed.password) if parsed.password else None),
+            username=downloader_config.username or None,
+            password=downloader_config.password or None,
             host=parsed.hostname or "localhost",
             port=parsed.port or 9091,
             path=parsed.path or "/transmission/rpc",

--- a/src/nemorosa/config.py
+++ b/src/nemorosa/config.py
@@ -4,7 +4,6 @@ import sys
 from enum import StrEnum
 from pathlib import Path
 from secrets import token_urlsafe
-from urllib.parse import urlparse
 
 import msgspec
 from humanfriendly import parse_timespan
@@ -106,6 +105,8 @@ class DownloaderConfig(msgspec.Struct):
 
     type: ClientType
     url: str
+    username: str = ""
+    password: str = ""
     torrents_dir: str = ""
     label: str | None = "nemorosa"
     tags: list[str] | None = None
@@ -139,13 +140,8 @@ class DownloaderConfig(msgspec.Struct):
 
     @property
     def client_key(self) -> str:
-        """Unique client identifier for database cache isolation (no credentials)."""
-        parsed = urlparse(self.url)
-        clean_netloc = parsed.hostname or ""
-        if parsed.port:
-            clean_netloc += f":{parsed.port}"
-        clean_url = f"{parsed.scheme}://{clean_netloc}{parsed.path}"
-        return f"{self.type.value}+{clean_url}"
+        """Unique client identifier for database cache isolation."""
+        return f"{self.type.value}+{self.url}"
 
 
 class ServerConfig(msgspec.Struct):
@@ -381,14 +377,16 @@ downloader:
   # Supported client types: deluge, transmission, qbittorrent, rtorrent
 
   # URL format examples:
-  # transmission: http://user:pass@host:port/transmission/rpc
-  # deluge: deluge://username:password@host:port
-  # qbittorrent: http://username:password@host:port
-  # rtorrent: http://RUTORRENT_ADDRESS:9380/plugins/rpc/rpc.php
+  # transmission: http://host:port/transmission/rpc
+  # deluge: deluge://host:port
+  # qbittorrent: http://host:port
+  # rtorrent: http://host:port/plugins/rpc/rpc.php
 
   # Client type: deluge, transmission, qbittorrent, rtorrent
   - type: "qbittorrent"
     url: "" # Client connection URL
+    username: "" # Client username
+    password: "" # Client password
     # The directory where your torrent client stores its .torrent files.
     # For qBittorrent 4.5.0+, torrents_dir is not needed.
     # For Windows: Use forward slashes (/) in path

--- a/src/nemorosa/webserver.py
+++ b/src/nemorosa/webserver.py
@@ -436,7 +436,7 @@ def run_webserver():
     )
     logger.info("Torrent clients configured: %d", len(config.cfg.downloaders))
     for i, dl in enumerate(config.cfg.downloaders, 1):
-        logger.info("  Client %d: %s", i, logger.redact_url_password(dl.url))
+        logger.info("  Client %d: %s", i, dl.url)
     logger.info("Target sites: %d", len(config.cfg.target_sites))
 
     # Check if API key is configured


### PR DESCRIPTION
BREAKING CHANGE: downloader configuration now uses separate `username` and `password` fields instead of embedding credentials in the URL. Users must update their config files to move credentials out of the URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Downloader config adds explicit username and password fields (no credentials embedded in URLs).
  * Torrent clients now use those explicit credentials for authentication.
  * Client identifier generation uses the raw URL string.
  * Startup and debug logs display configured connection URLs without credential redaction.
  * Default configuration examples updated to include username/password keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->