### PR TITLE
feat(filelinking): add tracker aliases

### DIFF
--- a/src/nemorosa/config.py
+++ b/src/nemorosa/config.py
@@ -66,6 +66,7 @@ class LinkingConfig(msgspec.Struct):
     enable_linking: bool = False
     link_dirs: list[str] = msgspec.field(default_factory=list)
     link_type: LinkType = LinkType.HARDLINK
+    tracker_aliases: dict[str, str] = msgspec.field(default_factory=dict)
 
     def __post_init__(self):
         # Validate link_dirs when linking is enabled
@@ -76,6 +77,15 @@ class LinkingConfig(msgspec.Struct):
             for item in self.link_dirs:
                 if not item.strip():
                     raise ValueError("link_dirs cannot contain empty strings")
+
+        # Validate tracker_aliases: keys and values must not be empty strings
+        for key, value in self.tracker_aliases.items():
+            if not key.strip():
+                raise ValueError("tracker_aliases cannot contain empty keys")
+            if not value.strip():
+                raise ValueError(
+                    f"tracker_aliases value for '{key}' cannot be an empty string"
+                )
 
 
 class GlobalConfig(msgspec.Struct):

--- a/src/nemorosa/filelinking.py
+++ b/src/nemorosa/filelinking.py
@@ -268,7 +268,12 @@ def create_file_links_for_torrent(
             logger.warning("No trackers found in torrent")
             return None
         tracker = torrent_object.trackers.flat[0]
-        tracker_name = urlparse(tracker).hostname or "unknown"
+        hostname = urlparse(tracker).hostname
+        tracker_name = (
+            config.cfg.linking.tracker_aliases.get(hostname, hostname)
+            if hostname
+            else "unknown"
+        )
 
         original_download_dir = local_download_dir / local_torrent_name
 


### PR DESCRIPTION
Add tracker aliases to allow linking cross-seeds to a different directory than the tracker hostname.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracker aliases configuration so users can map tracker identifiers to custom names for organizing linked downloads.
* **Behavior Change / Bug Fixes**
  * Alias mappings are validated to reject empty keys or values; invalid configs now fail fast.
  * Directory naming for linked files now respects aliases and falls back to "unknown" when no hostname is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->