### PR TITLE
refactor(filelinking): replace tracker_aliases with per-site link_dir_override

### DIFF
--- a/src/nemorosa/config.py
+++ b/src/nemorosa/config.py
@@ -66,7 +66,6 @@ class LinkingConfig(msgspec.Struct):
     enable_linking: bool = False
     link_dirs: list[str] = msgspec.field(default_factory=list)
     link_type: LinkType = LinkType.HARDLINK
-    tracker_aliases: dict[str, str] = msgspec.field(default_factory=dict)
 
     def __post_init__(self):
         # Validate link_dirs when linking is enabled
@@ -77,15 +76,6 @@ class LinkingConfig(msgspec.Struct):
             for item in self.link_dirs:
                 if not item.strip():
                     raise ValueError("link_dirs cannot contain empty strings")
-
-        # Validate tracker_aliases: keys and values must not be empty strings
-        for key, value in self.tracker_aliases.items():
-            if not key.strip():
-                raise ValueError("tracker_aliases cannot contain empty keys")
-            if not value.strip():
-                raise ValueError(
-                    f"tracker_aliases value for '{key}' cannot be an empty string"
-                )
 
 
 class GlobalConfig(msgspec.Struct):
@@ -206,6 +196,7 @@ class TargetSiteConfig(msgspec.Struct):
     server: str = ""
     api_key: str | None = None
     cookie: str | None = None
+    link_dir_override: str | None = None
 
     def __post_init__(self):
         if not self.server:
@@ -222,6 +213,9 @@ class TargetSiteConfig(msgspec.Struct):
             )
 
         self.server = self.server.rstrip("/")
+
+        if self.link_dir_override is not None and not self.link_dir_override.strip():
+            raise ValueError("link_dir_override cannot be an empty string")
 
 
 class NemorosaConfig(msgspec.Struct):
@@ -429,6 +423,8 @@ target_site:
     api_key: "your_api_key_here"
   - server: "https://dicmusic.com"
     cookie: "your_cookie_here" # For sites that don't support API, use cookie instead
+    # Optional: override link directory name (default: tracker URL hostname)
+    # link_dir_override: "custom_name"
 """
 
     target_path.write_text(default_config, encoding="utf-8")

--- a/src/nemorosa/core/injector.py
+++ b/src/nemorosa/core/injector.py
@@ -13,7 +13,7 @@ from ..filecompare import generate_link_map, generate_rename_map
 from ..filelinking import create_file_links_for_torrent
 
 # Type alias for the link function signature
-LinkFn = Callable[[Torrent, Path, str, dict[str, Any]], Path | None]
+LinkFn = Callable[[Torrent, Path, str, dict[str, Any], str], Path | None]
 
 
 class TorrentInjector:
@@ -22,7 +22,7 @@ class TorrentInjector:
     Args:
         link_fn: Optional file linking function. Defaults to
             create_file_links_for_torrent. Accepts (torrent_object,
-            download_dir, torrent_name, file_mapping) and returns
+            download_dir, torrent_name, file_mapping, link_dir) and returns
             linked directory path or None.
     """
 
@@ -45,6 +45,7 @@ class TorrentInjector:
         matched_fdict: dict[str, int],
         download_dir: str,
         torrent_name: str,
+        link_dir: str,
     ) -> str:
         """Prepare download directory with file linking if enabled.
 
@@ -54,6 +55,7 @@ class TorrentInjector:
             matched_fdict: Matched torrent file dictionary.
             download_dir: Original download directory.
             torrent_name: Name of the torrent.
+            link_dir: Override directory name under the link directory.
 
         Returns:
             Final download directory path (linked or original).
@@ -63,7 +65,11 @@ class TorrentInjector:
 
         file_mapping = generate_link_map(local_fdict, matched_fdict)
         final_dir = await asyncify(self.link_fn)(
-            torrent_object, Path(download_dir), torrent_name, file_mapping
+            torrent_object,
+            Path(download_dir),
+            torrent_name,
+            file_mapping,
+            link_dir,
         )
         if final_dir is None:
             logger.error(
@@ -77,6 +83,7 @@ class TorrentInjector:
         torrent_client: TorrentClient,
         matched_torrent: Torrent,
         local_torrent_info: ClientTorrentInfo,
+        link_dir: str,
         hash_match: bool = False,
     ) -> bool:
         """Inject matched torrent into client with file linking and renaming.
@@ -85,6 +92,7 @@ class TorrentInjector:
             torrent_client: TorrentClient instance to inject into.
             matched_torrent: The matched torrent to inject.
             local_torrent_info: Local torrent information.
+            link_dir: Subdirectory name under the link root directory.
             hash_match: Whether this is a hash match (skip verification).
 
         Returns:
@@ -99,6 +107,7 @@ class TorrentInjector:
             matched_fdict,
             local_torrent_info.download_dir,
             local_torrent_info.name,
+            link_dir,
         )
 
         logger.debug("Attempting to inject torrent: %s", local_torrent_info.name)

--- a/src/nemorosa/core/processor.py
+++ b/src/nemorosa/core/processor.py
@@ -186,6 +186,7 @@ class NemorosaCore:
                     torrent_client,
                     result.matched_torrent,
                     torrent_details,
+                    api.link_dir,
                     result.hash_match,
                 )
                 if injection_success:
@@ -425,6 +426,7 @@ class NemorosaCore:
                         owning_client,
                         matched_torrent,
                         local_torrent_info,
+                        api_instance.link_dir,
                         hash_match=False,
                     )
                     if success:
@@ -838,6 +840,7 @@ class NemorosaCore:
             fdict_torrent,
             matched_torrent.download_dir,
             matched_torrent.name,
+            torrent_api.link_dir,
         )
 
         success, _ = await owning_client.inject_torrent(

--- a/src/nemorosa/filelinking.py
+++ b/src/nemorosa/filelinking.py
@@ -8,7 +8,6 @@ import errno
 import shutil
 import uuid
 from pathlib import Path
-from urllib.parse import urlparse
 
 from reflink_copy import reflink, reflink_or_copy
 from torf import Torrent
@@ -250,6 +249,7 @@ def create_file_links_for_torrent(
     local_download_dir: Path,
     local_torrent_name: str,
     file_mapping: dict,
+    link_dir: str,
 ) -> Path | None:
     """Create file links for a torrent instead of renaming files.
 
@@ -258,28 +258,18 @@ def create_file_links_for_torrent(
         local_download_dir: Download directory.
         local_torrent_name: Torrent name.
         file_mapping: File mapping for linking operations.
+        link_dir: Subdirectory name under the link root directory.
 
     Returns:
-        Parent directory of the linked torrent (link_dir/tracker), or None if failed.
+        Parent directory of the linked torrent (link_root/link_dir), or
+        None if failed.
     """
     try:
-        # Extract tracker name from torrent data
-        if not torrent_object.trackers or not torrent_object.trackers.flat:
-            logger.warning("No trackers found in torrent")
-            return None
-        tracker = torrent_object.trackers.flat[0]
-        hostname = urlparse(tracker).hostname
-        tracker_name = (
-            config.cfg.linking.tracker_aliases.get(hostname, hostname)
-            if hostname
-            else "unknown"
-        )
-
         original_download_dir = local_download_dir / local_torrent_name
 
-        # Get the link directory
-        link_dir = get_link_directory(original_download_dir)
-        if not link_dir:
+        # Get the link root directory
+        link_root_dir = get_link_directory(original_download_dir)
+        if not link_root_dir:
             logger.warning(
                 "No suitable link directory found for %s", original_download_dir
             )
@@ -290,7 +280,7 @@ def create_file_links_for_torrent(
             return None
 
         # Create torrent-specific directory (following cross-seed structure)
-        final_download_dir = link_dir / tracker_name
+        final_download_dir = link_root_dir / link_dir
         torrent_link_dir = final_download_dir / torrent_object.name
 
         # Create directory links

--- a/src/nemorosa/trackers/api_common.py
+++ b/src/nemorosa/trackers/api_common.py
@@ -125,6 +125,7 @@ class GazelleBase(ABC):
 
         self._rate_limiter = None
         self.spec = spec
+        self.link_dir: str = urlparse(spec.tracker_url).hostname or "unknown"
 
     @property
     def rate_limiter(self) -> AsyncLimiter:

--- a/src/nemorosa/trackers/registry.py
+++ b/src/nemorosa/trackers/registry.py
@@ -169,6 +169,8 @@ async def init_api(target_sites: list[TargetSiteConfig]) -> None:
             api_instance = get_api_instance(
                 server=site.server, api_key=site.api_key, cookies=site_cookies
             )
+            if site.link_dir_override:
+                api_instance.link_dir = site.link_dir_override
             try:
                 await api_instance.auth()
                 target_apis.append(api_instance)

--- a/tests/core/test_injector.py
+++ b/tests/core/test_injector.py
@@ -41,6 +41,7 @@ class TestPrepareLinkedDownloadDir:
                 matched_fdict={"01 - Track.flac": 30000000},
                 download_dir="/downloads",
                 torrent_name="Test Album",
+                link_dir="test-tracker",
             )
 
         assert result == "/downloads"
@@ -63,6 +64,7 @@ class TestPrepareLinkedDownloadDir:
                 matched_fdict={"01 - Track.flac": 30000000},
                 download_dir="/downloads",
                 torrent_name="Test Album",
+                link_dir="test-tracker",
             )
 
         assert result == "/linked/dir"
@@ -85,6 +87,7 @@ class TestPrepareLinkedDownloadDir:
                 matched_fdict={"01 - Track.flac": 30000000},
                 download_dir="/downloads",
                 torrent_name="Test Album",
+                link_dir="test-tracker",
             )
 
         assert result == "/downloads"
@@ -108,7 +111,10 @@ class TestInjectMatchedTorrent:
             mock_config.cfg.linking.enable_linking = False
 
             result = await injector.inject_matched_torrent(
-                mock_torrent_client, sample_torrent, sample_local_info
+                mock_torrent_client,
+                sample_torrent,
+                sample_local_info,
+                link_dir="test-tracker",
             )
 
         assert result is True
@@ -128,7 +134,10 @@ class TestInjectMatchedTorrent:
             mock_config.cfg.linking.enable_linking = False
 
             result = await injector.inject_matched_torrent(
-                mock_torrent_client, sample_torrent, sample_local_info
+                mock_torrent_client,
+                sample_torrent,
+                sample_local_info,
+                link_dir="test-tracker",
             )
 
         assert result is False
@@ -145,7 +154,11 @@ class TestInjectMatchedTorrent:
             mock_config.cfg.linking.enable_linking = False
 
             await injector.inject_matched_torrent(
-                mock_torrent_client, sample_torrent, sample_local_info, hash_match=True
+                mock_torrent_client,
+                sample_torrent,
+                sample_local_info,
+                link_dir="test-tracker",
+                hash_match=True,
             )
 
         call_args = mock_torrent_client.inject_torrent.call_args
@@ -181,6 +194,7 @@ class TestInjectableLinkFn:
                 matched_fdict={"01 - Track.flac": 30000000},
                 download_dir="/downloads",
                 torrent_name="Test Album",
+                link_dir="test-tracker",
             )
 
         assert result == "/fake/linked/dir"
@@ -204,6 +218,7 @@ class TestInjectableLinkFn:
                 matched_fdict={"01 - Track.flac": 30000000},
                 download_dir="/downloads",
                 torrent_name="Test Album",
+                link_dir="test-tracker",
             )
 
         assert result == "/downloads"
@@ -228,7 +243,10 @@ class TestInjectableLinkFn:
             mock_config.cfg.linking.enable_linking = True
 
             result = await injector.inject_matched_torrent(
-                mock_torrent_client, sample_torrent, sample_local_info
+                mock_torrent_client,
+                sample_torrent,
+                sample_local_info,
+                link_dir="test-tracker",
             )
 
         assert result is True


### PR DESCRIPTION
Remove the global `linking.tracker_aliases` mapping and derive the link subdirectory from each tracker API instance instead. `GazelleBase` now exposes a `link_dir` attribute defaulted to the tracker URL hostname, which `init_api` can override via the per-site `link_dir_override` config. `create_file_links_for_torrent` and `inject_matched_torrent` take `link_dir` as an explicit argument, making the resolved value the single source of truth and removing the URL parsing previously done at link time.

- Drop `tracker_aliases` from `config.py`
- Add `link_dir` to `GazelleBase`; apply `link_dir_override` in `init_api`
- Thread `link_dir` through `processor` -> `injector` -> `filelinking`
- Update injector tests to pass `link_dir`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `link_dir_override` configuration option, providing granular control over file organization directories on a per-target-site basis for enhanced customization of file placement.

* **Chores**
  * Removed `tracker_aliases` configuration field from linking configuration, streamlining settings by consolidating directory management into the new per-site `link_dir_override` option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KyokoMiki/nemorosa/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->