### PR TITLE
Handle qBittorrent 5.2 torrents/add response

### DIFF
--- a/src/nemorosa/clients/qbittorrent.py
+++ b/src/nemorosa/clients/qbittorrent.py
@@ -411,6 +411,22 @@ class QBittorrentClient(TorrentClient):
         )
         return dupe_category, default_tags
 
+    def _add_succeeded(self, result: object, info_hash: str) -> bool:
+        """Whether a torrents/add response indicates the torrent was added.
+
+        qBittorrent < 5.2 returns the string ``"Ok."`` on success; 5.2+ returns
+        a JSON body such as ``{"added_torrent_ids": ["<hash>"], ...}``.
+        """
+        if result == "Ok.":
+            return True
+        if not isinstance(result, str):
+            return False
+        try:
+            added = json.loads(result).get("added_torrent_ids", [])
+        except (ValueError, TypeError):
+            return False
+        return info_hash.lower() in {h.lower() for h in added}
+
     async def _add_torrent(
         self,
         torrent_data: bytes,
@@ -489,18 +505,7 @@ class QBittorrentClient(TorrentClient):
             # (older versions returned "Fails." instead).
             raise TorrentConflictError(info_hash) from e
 
-        # qBittorrent < 5.2 returns "Ok."/"Fails."; 5.2+ returns a JSON body such as
-        # {"added_torrent_ids": ["<hash>"], "failure_count": 0, "success_count": 1}.
-        added_ok = result == "Ok."
-        if not added_ok and isinstance(result, str):
-            try:
-                added_ok = info_hash.lower() in {
-                    h.lower() for h in json.loads(result).get("added_torrent_ids", [])
-                }
-            except (ValueError, TypeError):
-                added_ok = False
-
-        if not added_ok:
+        if not self._add_succeeded(result, info_hash):
             # Check if torrent already exists by comparing add time
             try:
                 torrent_info = await asyncify(self.client.torrents_info)(

--- a/src/nemorosa/clients/qbittorrent.py
+++ b/src/nemorosa/clients/qbittorrent.py
@@ -3,6 +3,7 @@ qBittorrent client implementation.
 Provides integration with qBittorrent via its Web API.
 """
 
+import json
 import os
 import posixpath
 import time
@@ -469,22 +470,37 @@ class QBittorrentClient(TorrentClient):
 
         current_time = time.time()
 
-        result = await asyncify(self.client.torrents_add)(
-            torrent_files=torrent_data,
-            save_path=download_dir if not use_auto_tmm else None,
-            is_paused=True,
-            category=category,
-            tags=tags,
-            use_auto_torrent_management=use_auto_tmm,
-            is_skip_checking=hash_match,
-        )
-
         # qBittorrent doesn't return the hash directly, we need to decode it
         torrent_obj = Torrent.read_stream(torrent_data)
         info_hash = torrent_obj.infohash
 
-        # qBittorrent returns "Ok." for success and "Fails." for failure
-        if result != "Ok.":
+        try:
+            result = await asyncify(self.client.torrents_add)(
+                torrent_files=torrent_data,
+                save_path=download_dir if not use_auto_tmm else None,
+                is_paused=True,
+                category=category,
+                tags=tags,
+                use_auto_torrent_management=use_auto_tmm,
+                is_skip_checking=hash_match,
+            )
+        except qbittorrentapi.Conflict409Error as e:
+            # qBittorrent 5.2+ returns HTTP 409 when the torrent already exists
+            # (older versions returned "Fails." instead).
+            raise TorrentConflictError(info_hash) from e
+
+        # qBittorrent < 5.2 returns "Ok."/"Fails."; 5.2+ returns a JSON body such as
+        # {"added_torrent_ids": ["<hash>"], "failure_count": 0, "success_count": 1}.
+        added_ok = result == "Ok."
+        if not added_ok and isinstance(result, str):
+            try:
+                added_ok = info_hash.lower() in {
+                    h.lower() for h in json.loads(result).get("added_torrent_ids", [])
+                }
+            except (ValueError, TypeError):
+                added_ok = False
+
+        if not added_ok:
             # Check if torrent already exists by comparing add time
             try:
                 torrent_info = await asyncify(self.client.torrents_info)(

--- a/src/nemorosa/clients/qbittorrent.py
+++ b/src/nemorosa/clients/qbittorrent.py
@@ -3,7 +3,6 @@ qBittorrent client implementation.
 Provides integration with qBittorrent via its Web API.
 """
 
-import json
 import os
 import posixpath
 import time
@@ -12,6 +11,7 @@ from typing import TYPE_CHECKING
 import qbittorrentapi
 from anyio import Path
 from asyncer import asyncify
+from qbittorrentapi.torrents import TorrentsAddedMetadata
 from torf import Torrent
 
 from nemorosa import config, logger
@@ -411,21 +411,19 @@ class QBittorrentClient(TorrentClient):
         )
         return dupe_category, default_tags
 
-    def _add_succeeded(self, result: object, info_hash: str) -> bool:
+    def _add_succeeded(
+        self, result: str | TorrentsAddedMetadata, info_hash: str
+    ) -> bool:
         """Whether a torrents/add response indicates the torrent was added.
 
         qBittorrent < 5.2 returns the string ``"Ok."`` on success; 5.2+ returns
-        a JSON body such as ``{"added_torrent_ids": ["<hash>"], ...}``.
+        a TorrentsAddedMetadata object with added_torrent_ids list.
         """
         if result == "Ok.":
             return True
-        if not isinstance(result, str):
-            return False
-        try:
-            added = json.loads(result).get("added_torrent_ids", [])
-        except (ValueError, TypeError):
-            return False
-        return info_hash.lower() in {h.lower() for h in added}
+        if isinstance(result, TorrentsAddedMetadata):
+            return info_hash.lower() in {h.lower() for h in result.added_torrent_ids}
+        return False
 
     async def _add_torrent(
         self,


### PR DESCRIPTION
## Problem

qBittorrent **5.2** changed the WebUI `torrents/add` response in two ways:

- A **successful** add now returns a JSON body — e.g. `{"added_torrent_ids": ["<hash>"], "failure_count": 0, "success_count": 1}` — instead of the plain string `Ok.`.
- Adding an **already-present** torrent now returns **HTTP 409** instead of the string `Fails.`.

`QBittorrentClient._add_torrent` only treats a literal `"Ok."` as success, so on qBittorrent 5.2 every add falls into the failure branch. It then compares qbit's integer `added_on` against `time.time()`, which is true for a just-added torrent, and raises a bogus `TorrentConflictError` — aborting the verify and leaving the freshly-added torrent paused at 0%.

This reproduces on qBittorrent 5.2.2 with `qbittorrent-api` 2026.7.0, i.e. it's independent of the login fix in recent `qbittorrent-api` releases.

## Fix

In `_add_torrent`:

- Decode the info hash **before** the add so it's available to both branches.
- Recognize the 5.2 JSON success response: treat the add as successful when `added_torrent_ids` contains the torrent's info hash.
- Catch `qbittorrentapi.Conflict409Error` (the new 5.2 duplicate response) and route it through the existing `TorrentConflictError` path.

Behaviour on qBittorrent **< 5.2** (`"Ok."` / `"Fails."`) is unchanged — the existing `Fails.`/add-time duplicate-detection block is left exactly as-is, so both old and new servers are handled.

## Testing

- Verified against a live qBittorrent 5.2.2 instance: full matches now inject and verify to 100%, and already-present torrents are skipped cleanly as conflicts instead of erroring.
- `python -m py_compile` clean.

I didn't see an existing test for this client, so I kept the diff to the fix. Happy to add a unit test that mocks `torrents_add` returning the 5.2 JSON body / raising `Conflict409Error` if you'd like one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved torrent addition compatibility with newer qBittorrent responses.
  * More reliably detects whether a torrent was successfully added, including responses containing added torrent IDs.
  * Provides clearer conflict handling when a torrent already exists and uses info-hash matching to confirm outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->