### PR TITLE
feat(config): add opt-in keep_partial_torrents

### DIFF
--- a/src/nemorosa/clients/client_common.py
+++ b/src/nemorosa/clients/client_common.py
@@ -1234,9 +1234,9 @@ class TorrentClient(ABC):
                     )
                     result.status = PostProcessStatus.PARTIAL_KEPT
                 else:
-                    reflink_enabled = config.cfg.linking.link_type in (
-                        config.LinkType.REFLINK,
-                        config.LinkType.REFLINK_OR_COPY,
+                    reflink_enabled = config.cfg.linking.enable_linking and (
+                        config.cfg.linking.link_type
+                        in (config.LinkType.REFLINK, config.LinkType.REFLINK_OR_COPY)
                     )
                     if (
                         reflink_enabled

--- a/src/nemorosa/clients/client_common.py
+++ b/src/nemorosa/clients/client_common.py
@@ -1234,14 +1234,26 @@ class TorrentClient(ABC):
                     )
                     result.status = PostProcessStatus.PARTIAL_KEPT
                 else:
-                    if config.cfg.linking.link_type in (
+                    reflink_enabled = config.cfg.linking.link_type in (
                         config.LinkType.REFLINK,
                         config.LinkType.REFLINK_OR_COPY,
+                    )
+                    if (
+                        reflink_enabled
+                        or config.cfg.global_config.keep_partial_torrents
                     ):
-                        # Keep partial torrent explicitly due to reflink being enabled
+                        # Keep the partial match paused for manual review: either
+                        # reflink makes keeping it cheap, or the user opted in via
+                        # keep_partial_torrents.
+                        reason = (
+                            "reflink enabled"
+                            if reflink_enabled
+                            else "keep_partial_torrents enabled"
+                        )
                         logger.info(
-                            "Keeping partial torrent %s - kept due to reflink enabled",
+                            "Keeping partial torrent %s - kept due to %s",
                             matched_torrent.name,
+                            reason,
                         )
                         await self.database.update_scan_result_checked(
                             self.client_key, matched_torrent_hash, True

--- a/src/nemorosa/config.py
+++ b/src/nemorosa/config.py
@@ -89,6 +89,7 @@ class GlobalConfig(msgspec.Struct):
     )
     check_music_only: bool = True
     auto_start_torrents: bool = True
+    keep_partial_torrents: bool = False
     notification_urls: list[str] = msgspec.field(default_factory=list)
 
     def __post_init__(self):
@@ -357,6 +358,8 @@ global:
   check_music_only: true # Whether to check music files only
   # Whether to automatically start torrents after successful injection
   auto_start_torrents: true
+  # Keep partial matches paused for manual review instead of removing them
+  keep_partial_torrents: false
   # Apprise notification URLs
   # See: https://appriseit.com/services
   notification_urls: []

--- a/tests/clients/test_client_common.py
+++ b/tests/clients/test_client_common.py
@@ -109,7 +109,7 @@ async def test_partial_kept_when_opted_in(
 
         result = await client.post_process_single_injected_torrent(MATCHED_HASH)
 
-    assert result.status == PostProcessStatus.PARTIAL_KEPT
+    assert result.status == PostProcessStatus.PARTIAL_KEPT  # nosec B101
     client._remove_torrent.assert_not_awaited()
     client.database.update_scan_result_checked.assert_awaited_once_with(
         client.client_key, MATCHED_HASH, True
@@ -134,7 +134,7 @@ async def test_partial_removed_when_not_opted_in(
 
         result = await client.post_process_single_injected_torrent(MATCHED_HASH)
 
-    assert result.status == PostProcessStatus.PARTIAL_REMOVED
+    assert result.status == PostProcessStatus.PARTIAL_REMOVED  # nosec B101
     client._remove_torrent.assert_awaited_once_with(MATCHED_HASH)
     client.database.clear_matched_torrent_info.assert_awaited_once_with(
         client.client_key, MATCHED_HASH

--- a/tests/clients/test_client_common.py
+++ b/tests/clients/test_client_common.py
@@ -1,0 +1,142 @@
+"""Unit tests for ``TorrentClient.post_process_single_injected_torrent``.
+
+Focused on the ``keep_partial_torrents`` opt-in (PR #190): a partial match that
+fails ``should_keep_partial_torrent`` should be kept paused for manual review
+when the user opts in, and removed (today's default behaviour) otherwise.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nemorosa.clients.client_common import (
+    ClientTorrentInfo,
+    PostProcessStatus,
+    TorrentClient,
+    TorrentState,
+)
+
+pytestmark = pytest.mark.anyio
+
+MATCHED_HASH = "deadbeef"
+
+
+class _StubClient(TorrentClient):
+    """Concrete ``TorrentClient`` whose abstract methods are inert.
+
+    Only the members exercised by ``post_process_single_injected_torrent`` are
+    replaced with mocks in the ``client`` fixture; the remaining abstract
+    methods exist purely so the base class can be instantiated.
+    """
+
+    async def get_torrents(self, torrent_hashes=None, fields=None):
+        raise NotImplementedError
+
+    async def get_torrent_info(self, torrent_hash, fields):
+        raise NotImplementedError
+
+    async def get_torrents_for_monitoring(self, torrent_hashes):
+        raise NotImplementedError
+
+    async def _add_torrent(
+        self, torrent_data, download_dir, hash_match, local_torrent_hash=""
+    ):
+        raise NotImplementedError
+
+    async def _remove_torrent(self, torrent_hash):
+        raise NotImplementedError
+
+    async def _rename_torrent(self, torrent_hash, old_name, new_name):
+        raise NotImplementedError
+
+    async def _rename_file(self, torrent_hash, old_path, new_name):
+        raise NotImplementedError
+
+    async def _verify_torrent(self, torrent_hash):
+        raise NotImplementedError
+
+    async def _process_rename_map(self, torrent_hash, base_path, rename_map):
+        raise NotImplementedError
+
+    async def _get_torrent_data(self, torrent_hash):
+        raise NotImplementedError
+
+    async def _resume_torrent(self, torrent_hash):
+        raise NotImplementedError
+
+
+@pytest.fixture
+def client() -> _StubClient:
+    """Stub client with a mocked database and a mocked ``_remove_torrent``."""
+    downloader_config = MagicMock()
+    downloader_config.client_key = "test-client"
+
+    database = MagicMock()
+    database.update_scan_result_checked = AsyncMock()
+    database.clear_matched_torrent_info = AsyncMock()
+
+    stub = _StubClient(downloader_config, database, MagicMock(), notifier=None)
+    stub._remove_torrent = AsyncMock()
+    return stub
+
+
+@pytest.fixture
+def partial_torrent() -> ClientTorrentInfo:
+    """A partial (50%) match that is not currently being checked."""
+    return ClientTorrentInfo(
+        hash=MATCHED_HASH,
+        name="Some Artist - Some Album",
+        progress=0.5,
+        state=TorrentState.PAUSED,
+    )
+
+
+async def test_partial_kept_when_opted_in(
+    client: _StubClient, partial_torrent: ClientTorrentInfo
+) -> None:
+    """keep_partial_torrents=True keeps a failed-validation partial paused."""
+    client.get_torrent_info = AsyncMock(return_value=partial_torrent)
+
+    with (
+        patch("nemorosa.clients.client_common.config") as mock_config,
+        patch(
+            "nemorosa.clients.client_common.filecompare.should_keep_partial_torrent",
+            return_value=False,
+        ),
+    ):
+        mock_config.cfg.linking.enable_linking = False
+        mock_config.cfg.global_config.keep_partial_torrents = True
+
+        result = await client.post_process_single_injected_torrent(MATCHED_HASH)
+
+    assert result.status == PostProcessStatus.PARTIAL_KEPT
+    client._remove_torrent.assert_not_awaited()
+    client.database.update_scan_result_checked.assert_awaited_once_with(
+        client.client_key, MATCHED_HASH, True
+    )
+
+
+async def test_partial_removed_when_not_opted_in(
+    client: _StubClient, partial_torrent: ClientTorrentInfo
+) -> None:
+    """Default (opt-out, no reflink) removes the failed-validation partial."""
+    client.get_torrent_info = AsyncMock(return_value=partial_torrent)
+
+    with (
+        patch("nemorosa.clients.client_common.config") as mock_config,
+        patch(
+            "nemorosa.clients.client_common.filecompare.should_keep_partial_torrent",
+            return_value=False,
+        ),
+    ):
+        mock_config.cfg.linking.enable_linking = False
+        mock_config.cfg.global_config.keep_partial_torrents = False
+
+        result = await client.post_process_single_injected_torrent(MATCHED_HASH)
+
+    assert result.status == PostProcessStatus.PARTIAL_REMOVED
+    client._remove_torrent.assert_awaited_once_with(MATCHED_HASH)
+    client.database.clear_matched_torrent_info.assert_awaited_once_with(
+        client.client_key, MATCHED_HASH
+    )
+    client.database.update_scan_result_checked.assert_not_awaited()


### PR DESCRIPTION
## What

Adds an opt-in global setting **`keep_partial_torrents`** (default `false`).

When a matched torrent is only a partial match and fails `should_keep_partial_torrent`, nemorosa currently **removes** it ("failed validation") — unless reflink linking is enabled, in which case it's kept paused. This lets users opt into that keep-paused behaviour regardless of link type.

## Why

For a near-complete match I'd often rather finish the last few percent by hand than discard the injection outright. With `keep_partial_torrents: true`, those partials stay paused in the client for manual review (start or delete) instead of being auto-removed.

## Behaviour

- **Default `false`** → identical to today's behaviour; no change for existing users.
- **`true`** → partial matches that would be removed are instead kept paused (`PARTIAL_KEPT`), the same path reflink already uses.
- Also fixes the kept-partial log line to report the real reason (`reflink enabled` vs `keep_partial_torrents enabled`) instead of always saying "reflink enabled".

## Notes

I kept it a simple boolean for now — happy to make it a threshold instead (e.g. keep only if ≥ N% complete) if you'd prefer that shape. I didn't see an existing test covering this post-process branch, so I left the diff minimal; glad to add one if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to retain partial torrents after processing.
  * Partial torrents can now be preserved when retention is enabled or compatible reflink linking is active.

* **Bug Fixes**
  * Partial torrents are removed by default when validation fails, with related match information cleared.
  * Retained partial torrents remain paused and are clearly marked.

* **Documentation**
  * Updated the default configuration template with the new retention setting and an explanatory comment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->